### PR TITLE
bug: ビルド時にTailwind CSSを適用する

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 const nextConfig: NextConfig = {
   /* config options here */
   output: "export",
+  basePath: "/blog",
   webpack: config => {
     // Vue と同じように 「@ = src/」,「~ = src/」に設定する。
     // => モジュールのパス解決とエイリアスを設定している。


### PR DESCRIPTION
## 変更の概要

現状のサイトではCSSの適用がうまくいってない．（https://shirakasu.github.io/blog/ ）
設定ファイルの改善を行って，Tailwind CSSがビルド時に適用されるように修正

## 詳細

本来，https://shirakasu.github.io/blog/_next/~ を参照してほしいが，ビルド後にはhttps://shirakasu.github.io/_next/~ を参照してしまっている．このパスずれを解消するために，nextの設定ファイルにbasepathを設定した．

参考画像
<img width="1582" height="1058" alt="image" src="https://github.com/user-attachments/assets/a0fbf58b-4378-4b33-82cf-d52fe58f2479" />

## テスト

ローカルでビルドした結果，コードは/blogから始まっている．
<img width="1583" height="1067" alt="image" src="https://github.com/user-attachments/assets/f83848b0-13a4-4b3f-b80f-5e0bdf187ea9" />
